### PR TITLE
Add ability to change MaxConcurrent value of an OperationQueue

### DIFF
--- a/Punchclock.Tests/OperationQueue.cs
+++ b/Punchclock.Tests/OperationQueue.cs
@@ -277,5 +277,104 @@ namespace Punchclock.Tests
             Assert.Equal(0, output.Count);
             Assert.False(wasCalled);
         }
+
+        [Fact]
+        public void QueueShouldRespectMaximumConcurrent()
+        {
+            var unkeyed1Subj = new AsyncSubject<int>();
+            var unkeyed1SubCount = 0;
+            var unkeyed1 = Observable.Defer(() =>
+            {
+                unkeyed1SubCount++;
+                return unkeyed1Subj;
+            });
+
+            var unkeyed2Subj = new AsyncSubject<int>();
+            var unkeyed2SubCount = 0;
+            var unkeyed2 = Observable.Defer(() =>
+            {
+                unkeyed2SubCount++;
+                return unkeyed2Subj;
+            });
+
+            var unkeyed3Subj = new AsyncSubject<int>();
+            var unkeyed3SubCount = 0;
+            var unkeyed3 = Observable.Defer(() =>
+            {
+                unkeyed3SubCount++;
+                return unkeyed3Subj;
+            });
+
+            var fixture = new OperationQueue(2);
+            Assert.Equal(0, unkeyed1SubCount);
+            Assert.Equal(0, unkeyed2SubCount);
+            Assert.Equal(0, unkeyed3SubCount);
+
+            fixture.EnqueueObservableOperation(5, () => unkeyed1);
+            fixture.EnqueueObservableOperation(5, () => unkeyed2);
+            fixture.EnqueueObservableOperation(5, () => unkeyed3);
+            Assert.Equal(1, unkeyed1SubCount);
+            Assert.Equal(1, unkeyed2SubCount);
+            Assert.Equal(0, unkeyed3SubCount);
+        }
+
+        [Fact]
+        public void ShouldBeAbleToChangeTheMaximunConcurrentValueOfAnExistingQueue()
+        {
+            var unkeyed1Subj = new AsyncSubject<int>();
+            var unkeyed1SubCount = 0;
+            var unkeyed1 = Observable.Defer(() =>
+            {
+                unkeyed1SubCount++;
+                return unkeyed1Subj;
+            });
+
+            var unkeyed2Subj = new AsyncSubject<int>();
+            var unkeyed2SubCount = 0;
+            var unkeyed2 = Observable.Defer(() =>
+            {
+                unkeyed2SubCount++;
+                return unkeyed2Subj;
+            });
+
+            var unkeyed3Subj = new AsyncSubject<int>();
+            var unkeyed3SubCount = 0;
+            var unkeyed3 = Observable.Defer(() =>
+            {
+                unkeyed3SubCount++;
+                return unkeyed3Subj;
+            });
+
+            var unkeyed4Subj = new AsyncSubject<int>();
+            var unkeyed4SubCount = 0;
+            var unkeyed4 = Observable.Defer(() =>
+            {
+                unkeyed4SubCount++;
+                return unkeyed4Subj;
+            });
+
+            var fixture = new OperationQueue(2);
+            Assert.Equal(0, unkeyed1SubCount);
+            Assert.Equal(0, unkeyed2SubCount);
+            Assert.Equal(0, unkeyed3SubCount);
+            Assert.Equal(0, unkeyed4SubCount);
+
+            fixture.EnqueueObservableOperation(5, () => unkeyed1);
+            fixture.EnqueueObservableOperation(5, () => unkeyed2);
+            fixture.EnqueueObservableOperation(5, () => unkeyed3);
+            fixture.EnqueueObservableOperation(5, () => unkeyed4);
+            
+            Assert.Equal(1, unkeyed1SubCount);
+            Assert.Equal(1, unkeyed2SubCount);
+            Assert.Equal(0, unkeyed3SubCount);
+            Assert.Equal(0, unkeyed4SubCount);
+            
+            fixture.ChangeMaximunConcurrent(3);
+            
+            Assert.Equal(1, unkeyed1SubCount);
+            Assert.Equal(1, unkeyed2SubCount);
+            Assert.Equal(1, unkeyed3SubCount);
+            Assert.Equal(0, unkeyed4SubCount);
+        }
     }
 }

--- a/Punchclock/OperationQueue.cs
+++ b/Punchclock/OperationQueue.cs
@@ -75,7 +75,7 @@ namespace Punchclock
         readonly Subject<KeyedOperation> queuedOps = new Subject<KeyedOperation>();
         readonly IConnectableObservable<KeyedOperation> resultObs;
         readonly PrioritySemaphoreSubject<KeyedOperation> scheduledGate;
-        readonly int maximumConcurrent;
+        int maximumConcurrent;
 
         static int sequenceNumber = 0;
         int pauseRefCount = 0;
@@ -184,6 +184,18 @@ namespace Punchclock
 
                 scheduledGate.MaximumCount = maximumConcurrent;
             });
+        }
+
+        public void ChangeMaximunConcurrent(int maximumConcurrent)
+        {
+            using (this.PauseQueue())
+            {
+                // I'm not sure this lock is needed here.
+                lock (queuedOps)
+                {
+                    this.maximumConcurrent = maximumConcurrent;
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Hi @paulcbetts, It's been a while since I opened the issue #5, but here is is my first pass on allowing the MaxConcurrent value on a given OperationQueue to change.

I added couple tests to validate my implementation, but I'm not sure they are comprehensive enough. Let me know if I'm missing something here.

Fixes #5
