### PR TITLE
housekeeping: Add PackageIconUrl

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -21,6 +21,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <!-- Optional: Include PDB in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <PackageIconUrl>https://raw.githubusercontent.com/reactiveui/styleguide/master/logo_punchclock/main.png?raw=true</PackageIconUrl>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(IsTestProject)">


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

After we publish a new Punchclock version, a new icon will be displayed in the NuGet package manager GUI.