### PR TITLE
Update copyright year to 2025 and add .NET 9 test target

### DIFF
--- a/src/Punchclock.Tests/API/ApiApprovalTests.PunchclockTests.DotNet9_0.verified.txt
+++ b/src/Punchclock.Tests/API/ApiApprovalTests.PunchclockTests.DotNet9_0.verified.txt
@@ -1,0 +1,25 @@
+﻿[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
+namespace Punchclock
+{
+    public class OperationQueue : System.IDisposable
+    {
+        public OperationQueue(int maximumConcurrent = 4) { }
+        public void Dispose() { }
+        protected virtual void Dispose(bool isDisposing) { }
+        public System.IObservable<T> EnqueueObservableOperation<T>(int priority, System.Func<System.IObservable<T>> asyncCalculationFunc) { }
+        public System.IObservable<T> EnqueueObservableOperation<T>(int priority, string key, System.Func<System.IObservable<T>> asyncCalculationFunc) { }
+        public System.IObservable<T> EnqueueObservableOperation<T, TDontCare>(int priority, string key, System.IObservable<TDontCare> cancel, System.Func<System.IObservable<T>> asyncCalculationFunc) { }
+        public System.IDisposable PauseQueue() { }
+        public void SetMaximumConcurrent(int maximumConcurrent) { }
+        public System.IObservable<System.Reactive.Unit> ShutdownQueue() { }
+    }
+    public static class OperationQueueExtensions
+    {
+        public static System.Threading.Tasks.Task Enqueue(this Punchclock.OperationQueue operationQueue, int priority, System.Func<System.Threading.Tasks.Task> asyncOperation) { }
+        public static System.Threading.Tasks.Task Enqueue(this Punchclock.OperationQueue operationQueue, int priority, string key, System.Func<System.Threading.Tasks.Task> asyncOperation) { }
+        public static System.Threading.Tasks.Task Enqueue(this Punchclock.OperationQueue operationQueue, int priority, string key, System.Func<System.Threading.Tasks.Task> asyncOperation, System.Threading.CancellationToken token) { }
+        public static System.Threading.Tasks.Task<T> Enqueue<T>(this Punchclock.OperationQueue operationQueue, int priority, System.Func<System.Threading.Tasks.Task<T>> asyncOperation) { }
+        public static System.Threading.Tasks.Task<T> Enqueue<T>(this Punchclock.OperationQueue operationQueue, int priority, string key, System.Func<System.Threading.Tasks.Task<T>> asyncOperation) { }
+        public static System.Threading.Tasks.Task<T> Enqueue<T>(this Punchclock.OperationQueue operationQueue, int priority, string key, System.Func<System.Threading.Tasks.Task<T>> asyncOperation, System.Threading.CancellationToken token) { }
+    }
+}

--- a/src/Punchclock.Tests/API/ApiApprovalTests.cs
+++ b/src/Punchclock.Tests/API/ApiApprovalTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Punchclock.Tests/API/ApiExtensions.cs
+++ b/src/Punchclock.Tests/API/ApiExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Punchclock.Tests/OperationQueueTests.cs
+++ b/src/Punchclock.Tests/OperationQueueTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Punchclock.Tests/Punchclock.Tests.csproj
+++ b/src/Punchclock.Tests/Punchclock.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
 		<TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net472</TargetFrameworks>
-		<NoWarn>$(NoWarn);1591;CA1707;SA1633</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -10,7 +9,7 @@
 		<PackageReference Include="splat" Version="15.*" />
 		<PackageReference Include="PublicApiGenerator" Version="11.4.6" />
 		<PackageReference Include="Verify.Xunit" Version="28.16.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.console" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.1" />

--- a/src/Punchclock/KeyedOperation.cs
+++ b/src/Punchclock/KeyedOperation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Punchclock/OperationQueue.cs
+++ b/src/Punchclock/OperationQueue.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Punchclock/OperationQueueExtensions.cs
+++ b/src/Punchclock/OperationQueueExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Punchclock/PriorityQueue.cs
+++ b/src/Punchclock/PriorityQueue.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Punchclock/PrioritySemaphoreSubject.cs
+++ b/src/Punchclock/PrioritySemaphoreSubject.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/Punchclock/ScheduledSubject.cs
+++ b/src/Punchclock/ScheduledSubject.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/stylecop.json
+++ b/src/stylecop.json
@@ -13,7 +13,7 @@
             "documentPrivateFields": false,
             "documentationCulture": "en-US",
             "companyName": ".NET Foundation and Contributors",
-            "copyrightText": "Copyright (c) 2024 {companyName}. All rights reserved.\nLicensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the {licenseName} license.\nSee the {licenseFile} file in the project root for full license information.",
+            "copyrightText": "Copyright (c) 2025 {companyName}. All rights reserved.\nLicensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the {licenseName} license.\nSee the {licenseFile} file in the project root for full license information.",
             "variables": {
                 "licenseName": "MIT",
                 "licenseFile": "LICENSE"


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

update

**What is the new behavior?**
<!-- If this is a feature change -->

Changed copyright year to 2025 across all source and test files. Updated test project to target net8.0 and net9.0, removed net6.0, and bumped Microsoft.NET.Test.Sdk to 17.14.1. Added API approval file for .NET 9.0.

**What might this PR break?**

N/A

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

