### PR TITLE
feat(reactive): add Punchclock.Reactive package

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -14,7 +14,8 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="5.0.0-1.25277.114" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.0.0-1.25277.114" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.27.0.140913" />
-		<PackageVersion Include="ReactiveUI.Primitives" Version="5.4.0" />
+		<PackageVersion Include="ReactiveUI.Primitives" Version="5.6.0" />
+    <PackageVersion Include="ReactiveUI.Primitives.Reactive" Version="5.6.0" />
   </ItemGroup>
 
   <!-- Benchmarks + tests -->

--- a/src/Punchclock.Reactive/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/Punchclock.Reactive/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -1,0 +1,29 @@
+#nullable enable
+Punchclock.Reactive.OperationQueue
+Punchclock.Reactive.OperationQueue.Dispose() -> void
+Punchclock.Reactive.OperationQueue.EnqueueObservableOperation<T, TDontCare>(int priority, string! key, System.IObservable<TDontCare>! cancel, System.Func<System.IObservable<T>!>! asyncCalculationFunc) -> System.IObservable<T>!
+Punchclock.Reactive.OperationQueue.EnqueueObservableOperation<T>(int priority, string! key, System.Func<System.IObservable<T>!>! asyncCalculationFunc) -> System.IObservable<T>!
+Punchclock.Reactive.OperationQueue.EnqueueObservableOperation<T>(int priority, System.Func<System.IObservable<T>!>! asyncCalculationFunc) -> System.IObservable<T>!
+Punchclock.Reactive.OperationQueue.OperationQueue() -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent, bool randomizeEqualPriority, int? seed, System.Reactive.Concurrency.IScheduler? scheduler) -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent, bool randomizeEqualPriority, int? seed) -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent, System.Reactive.Concurrency.IScheduler! scheduler) -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent) -> void
+Punchclock.Reactive.OperationQueue.PauseQueue() -> System.IDisposable!
+Punchclock.Reactive.OperationQueue.SetMaximumConcurrent(int maximumConcurrent) -> void
+Punchclock.Reactive.OperationQueue.ShutdownQueue() -> System.IObservable<System.Reactive.Unit>!
+Punchclock.Reactive.OperationQueueExtensions
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!)
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue(int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue(int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue(int priority, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue<T>(int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue<T>(int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue<T>(int priority, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue<T>(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue<T>(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue<T>(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+virtual Punchclock.Reactive.OperationQueue.Dispose(bool isDisposing) -> void

--- a/src/Punchclock.Reactive/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Punchclock.Reactive/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Punchclock.Reactive/PublicAPI/net11.0/PublicAPI.Shipped.txt
+++ b/src/Punchclock.Reactive/PublicAPI/net11.0/PublicAPI.Shipped.txt
@@ -1,0 +1,29 @@
+#nullable enable
+Punchclock.Reactive.OperationQueue
+Punchclock.Reactive.OperationQueue.Dispose() -> void
+Punchclock.Reactive.OperationQueue.EnqueueObservableOperation<T, TDontCare>(int priority, string! key, System.IObservable<TDontCare>! cancel, System.Func<System.IObservable<T>!>! asyncCalculationFunc) -> System.IObservable<T>!
+Punchclock.Reactive.OperationQueue.EnqueueObservableOperation<T>(int priority, string! key, System.Func<System.IObservable<T>!>! asyncCalculationFunc) -> System.IObservable<T>!
+Punchclock.Reactive.OperationQueue.EnqueueObservableOperation<T>(int priority, System.Func<System.IObservable<T>!>! asyncCalculationFunc) -> System.IObservable<T>!
+Punchclock.Reactive.OperationQueue.OperationQueue() -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent, bool randomizeEqualPriority, int? seed, System.Reactive.Concurrency.IScheduler? scheduler) -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent, bool randomizeEqualPriority, int? seed) -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent, System.Reactive.Concurrency.IScheduler! scheduler) -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent) -> void
+Punchclock.Reactive.OperationQueue.PauseQueue() -> System.IDisposable!
+Punchclock.Reactive.OperationQueue.SetMaximumConcurrent(int maximumConcurrent) -> void
+Punchclock.Reactive.OperationQueue.ShutdownQueue() -> System.IObservable<System.Reactive.Unit>!
+Punchclock.Reactive.OperationQueueExtensions
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!)
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue(int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue(int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue(int priority, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue<T>(int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue<T>(int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue<T>(int priority, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue<T>(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue<T>(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue<T>(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+virtual Punchclock.Reactive.OperationQueue.Dispose(bool isDisposing) -> void

--- a/src/Punchclock.Reactive/PublicAPI/net11.0/PublicAPI.Unshipped.txt
+++ b/src/Punchclock.Reactive/PublicAPI/net11.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Punchclock.Reactive/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/Punchclock.Reactive/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -1,0 +1,29 @@
+#nullable enable
+Punchclock.Reactive.OperationQueue
+Punchclock.Reactive.OperationQueue.Dispose() -> void
+Punchclock.Reactive.OperationQueue.EnqueueObservableOperation<T, TDontCare>(int priority, string! key, System.IObservable<TDontCare>! cancel, System.Func<System.IObservable<T>!>! asyncCalculationFunc) -> System.IObservable<T>!
+Punchclock.Reactive.OperationQueue.EnqueueObservableOperation<T>(int priority, string! key, System.Func<System.IObservable<T>!>! asyncCalculationFunc) -> System.IObservable<T>!
+Punchclock.Reactive.OperationQueue.EnqueueObservableOperation<T>(int priority, System.Func<System.IObservable<T>!>! asyncCalculationFunc) -> System.IObservable<T>!
+Punchclock.Reactive.OperationQueue.OperationQueue() -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent, bool randomizeEqualPriority, int? seed, System.Reactive.Concurrency.IScheduler? scheduler) -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent, bool randomizeEqualPriority, int? seed) -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent, System.Reactive.Concurrency.IScheduler! scheduler) -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent) -> void
+Punchclock.Reactive.OperationQueue.PauseQueue() -> System.IDisposable!
+Punchclock.Reactive.OperationQueue.SetMaximumConcurrent(int maximumConcurrent) -> void
+Punchclock.Reactive.OperationQueue.ShutdownQueue() -> System.IObservable<System.Reactive.Unit>!
+Punchclock.Reactive.OperationQueueExtensions
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!)
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue(int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue(int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue(int priority, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue<T>(int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue<T>(int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue<T>(int priority, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue<T>(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue<T>(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue<T>(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+virtual Punchclock.Reactive.OperationQueue.Dispose(bool isDisposing) -> void

--- a/src/Punchclock.Reactive/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Punchclock.Reactive/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Punchclock.Reactive/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/Punchclock.Reactive/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -1,0 +1,29 @@
+#nullable enable
+Punchclock.Reactive.OperationQueue
+Punchclock.Reactive.OperationQueue.Dispose() -> void
+Punchclock.Reactive.OperationQueue.EnqueueObservableOperation<T, TDontCare>(int priority, string! key, System.IObservable<TDontCare>! cancel, System.Func<System.IObservable<T>!>! asyncCalculationFunc) -> System.IObservable<T>!
+Punchclock.Reactive.OperationQueue.EnqueueObservableOperation<T>(int priority, string! key, System.Func<System.IObservable<T>!>! asyncCalculationFunc) -> System.IObservable<T>!
+Punchclock.Reactive.OperationQueue.EnqueueObservableOperation<T>(int priority, System.Func<System.IObservable<T>!>! asyncCalculationFunc) -> System.IObservable<T>!
+Punchclock.Reactive.OperationQueue.OperationQueue() -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent, bool randomizeEqualPriority, int? seed, System.Reactive.Concurrency.IScheduler? scheduler) -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent, bool randomizeEqualPriority, int? seed) -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent, System.Reactive.Concurrency.IScheduler! scheduler) -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent) -> void
+Punchclock.Reactive.OperationQueue.PauseQueue() -> System.IDisposable!
+Punchclock.Reactive.OperationQueue.SetMaximumConcurrent(int maximumConcurrent) -> void
+Punchclock.Reactive.OperationQueue.ShutdownQueue() -> System.IObservable<System.Reactive.Unit>!
+Punchclock.Reactive.OperationQueueExtensions
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!)
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue(int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue(int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue(int priority, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue<T>(int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue<T>(int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue<T>(int priority, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue<T>(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue<T>(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue<T>(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+virtual Punchclock.Reactive.OperationQueue.Dispose(bool isDisposing) -> void

--- a/src/Punchclock.Reactive/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/Punchclock.Reactive/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Punchclock.Reactive/PublicAPI/net48/PublicAPI.Shipped.txt
+++ b/src/Punchclock.Reactive/PublicAPI/net48/PublicAPI.Shipped.txt
@@ -1,0 +1,29 @@
+#nullable enable
+Punchclock.Reactive.OperationQueue
+Punchclock.Reactive.OperationQueue.Dispose() -> void
+Punchclock.Reactive.OperationQueue.EnqueueObservableOperation<T, TDontCare>(int priority, string! key, System.IObservable<TDontCare>! cancel, System.Func<System.IObservable<T>!>! asyncCalculationFunc) -> System.IObservable<T>!
+Punchclock.Reactive.OperationQueue.EnqueueObservableOperation<T>(int priority, string! key, System.Func<System.IObservable<T>!>! asyncCalculationFunc) -> System.IObservable<T>!
+Punchclock.Reactive.OperationQueue.EnqueueObservableOperation<T>(int priority, System.Func<System.IObservable<T>!>! asyncCalculationFunc) -> System.IObservable<T>!
+Punchclock.Reactive.OperationQueue.OperationQueue() -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent, bool randomizeEqualPriority, int? seed, System.Reactive.Concurrency.IScheduler? scheduler) -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent, bool randomizeEqualPriority, int? seed) -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent, System.Reactive.Concurrency.IScheduler! scheduler) -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent) -> void
+Punchclock.Reactive.OperationQueue.PauseQueue() -> System.IDisposable!
+Punchclock.Reactive.OperationQueue.SetMaximumConcurrent(int maximumConcurrent) -> void
+Punchclock.Reactive.OperationQueue.ShutdownQueue() -> System.IObservable<System.Reactive.Unit>!
+Punchclock.Reactive.OperationQueueExtensions
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!)
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue(int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue(int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue(int priority, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue<T>(int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue<T>(int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue<T>(int priority, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue<T>(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue<T>(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue<T>(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+virtual Punchclock.Reactive.OperationQueue.Dispose(bool isDisposing) -> void

--- a/src/Punchclock.Reactive/PublicAPI/net48/PublicAPI.Unshipped.txt
+++ b/src/Punchclock.Reactive/PublicAPI/net48/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Punchclock.Reactive/PublicAPI/net481/PublicAPI.Shipped.txt
+++ b/src/Punchclock.Reactive/PublicAPI/net481/PublicAPI.Shipped.txt
@@ -1,0 +1,29 @@
+#nullable enable
+Punchclock.Reactive.OperationQueue
+Punchclock.Reactive.OperationQueue.Dispose() -> void
+Punchclock.Reactive.OperationQueue.EnqueueObservableOperation<T, TDontCare>(int priority, string! key, System.IObservable<TDontCare>! cancel, System.Func<System.IObservable<T>!>! asyncCalculationFunc) -> System.IObservable<T>!
+Punchclock.Reactive.OperationQueue.EnqueueObservableOperation<T>(int priority, string! key, System.Func<System.IObservable<T>!>! asyncCalculationFunc) -> System.IObservable<T>!
+Punchclock.Reactive.OperationQueue.EnqueueObservableOperation<T>(int priority, System.Func<System.IObservable<T>!>! asyncCalculationFunc) -> System.IObservable<T>!
+Punchclock.Reactive.OperationQueue.OperationQueue() -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent, bool randomizeEqualPriority, int? seed, System.Reactive.Concurrency.IScheduler? scheduler) -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent, bool randomizeEqualPriority, int? seed) -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent, System.Reactive.Concurrency.IScheduler! scheduler) -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent) -> void
+Punchclock.Reactive.OperationQueue.PauseQueue() -> System.IDisposable!
+Punchclock.Reactive.OperationQueue.SetMaximumConcurrent(int maximumConcurrent) -> void
+Punchclock.Reactive.OperationQueue.ShutdownQueue() -> System.IObservable<System.Reactive.Unit>!
+Punchclock.Reactive.OperationQueueExtensions
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!)
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue(int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue(int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue(int priority, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue<T>(int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue<T>(int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue<T>(int priority, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue<T>(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue<T>(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue<T>(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+virtual Punchclock.Reactive.OperationQueue.Dispose(bool isDisposing) -> void

--- a/src/Punchclock.Reactive/PublicAPI/net481/PublicAPI.Unshipped.txt
+++ b/src/Punchclock.Reactive/PublicAPI/net481/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Punchclock.Reactive/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/Punchclock.Reactive/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -1,0 +1,29 @@
+#nullable enable
+Punchclock.Reactive.OperationQueue
+Punchclock.Reactive.OperationQueue.Dispose() -> void
+Punchclock.Reactive.OperationQueue.EnqueueObservableOperation<T, TDontCare>(int priority, string! key, System.IObservable<TDontCare>! cancel, System.Func<System.IObservable<T>!>! asyncCalculationFunc) -> System.IObservable<T>!
+Punchclock.Reactive.OperationQueue.EnqueueObservableOperation<T>(int priority, string! key, System.Func<System.IObservable<T>!>! asyncCalculationFunc) -> System.IObservable<T>!
+Punchclock.Reactive.OperationQueue.EnqueueObservableOperation<T>(int priority, System.Func<System.IObservable<T>!>! asyncCalculationFunc) -> System.IObservable<T>!
+Punchclock.Reactive.OperationQueue.OperationQueue() -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent, bool randomizeEqualPriority, int? seed, System.Reactive.Concurrency.IScheduler? scheduler) -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent, bool randomizeEqualPriority, int? seed) -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent, System.Reactive.Concurrency.IScheduler! scheduler) -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent) -> void
+Punchclock.Reactive.OperationQueue.PauseQueue() -> System.IDisposable!
+Punchclock.Reactive.OperationQueue.SetMaximumConcurrent(int maximumConcurrent) -> void
+Punchclock.Reactive.OperationQueue.ShutdownQueue() -> System.IObservable<System.Reactive.Unit>!
+Punchclock.Reactive.OperationQueueExtensions
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!)
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue(int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue(int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue(int priority, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue<T>(int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue<T>(int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue<T>(int priority, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue<T>(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue<T>(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue<T>(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+virtual Punchclock.Reactive.OperationQueue.Dispose(bool isDisposing) -> void

--- a/src/Punchclock.Reactive/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Punchclock.Reactive/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Punchclock.Reactive/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/src/Punchclock.Reactive/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -1,0 +1,29 @@
+#nullable enable
+Punchclock.Reactive.OperationQueue
+Punchclock.Reactive.OperationQueue.Dispose() -> void
+Punchclock.Reactive.OperationQueue.EnqueueObservableOperation<T, TDontCare>(int priority, string! key, System.IObservable<TDontCare>! cancel, System.Func<System.IObservable<T>!>! asyncCalculationFunc) -> System.IObservable<T>!
+Punchclock.Reactive.OperationQueue.EnqueueObservableOperation<T>(int priority, string! key, System.Func<System.IObservable<T>!>! asyncCalculationFunc) -> System.IObservable<T>!
+Punchclock.Reactive.OperationQueue.EnqueueObservableOperation<T>(int priority, System.Func<System.IObservable<T>!>! asyncCalculationFunc) -> System.IObservable<T>!
+Punchclock.Reactive.OperationQueue.OperationQueue() -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent, bool randomizeEqualPriority, int? seed, System.Reactive.Concurrency.IScheduler? scheduler) -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent, bool randomizeEqualPriority, int? seed) -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent, System.Reactive.Concurrency.IScheduler! scheduler) -> void
+Punchclock.Reactive.OperationQueue.OperationQueue(int maximumConcurrent) -> void
+Punchclock.Reactive.OperationQueue.PauseQueue() -> System.IDisposable!
+Punchclock.Reactive.OperationQueue.SetMaximumConcurrent(int maximumConcurrent) -> void
+Punchclock.Reactive.OperationQueue.ShutdownQueue() -> System.IObservable<System.Reactive.Unit>!
+Punchclock.Reactive.OperationQueueExtensions
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!)
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue(int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue(int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue(int priority, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue<T>(int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue<T>(int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+Punchclock.Reactive.OperationQueueExtensions.extension(Punchclock.Reactive.OperationQueue!).Enqueue<T>(int priority, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, System.Func<System.Threading.Tasks.Task!>! asyncOperation) -> System.Threading.Tasks.Task!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue<T>(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<T>!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue<T>(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, string! key, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+static Punchclock.Reactive.OperationQueueExtensions.Enqueue<T>(this Punchclock.Reactive.OperationQueue! operationQueue, int priority, System.Func<System.Threading.Tasks.Task<T>!>! asyncOperation) -> System.Threading.Tasks.Task<T>!
+virtual Punchclock.Reactive.OperationQueue.Dispose(bool isDisposing) -> void

--- a/src/Punchclock.Reactive/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/Punchclock.Reactive/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Punchclock.Reactive/Punchclock.Reactive.csproj
+++ b/src/Punchclock.Reactive/Punchclock.Reactive.csproj
@@ -1,7 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
-	</PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFrameworks>$(LibraryTargetFrameworks)</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <DefineConstants>$(DefineConstants);REACTIVE_SHIM</DefineConstants>
+  </PropertyGroup>
   <!-- Inject nullable-annotation attribute polyfills on frameworks that lack them. -->
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <Compile Include="..\Polyfills\NotNullWhenAttribute.cs" Link="Polyfills\NotNullWhenAttribute.cs" />
@@ -11,7 +15,6 @@
     <Compile Include="..\Polyfills\IsExternalInit.cs" Link="Polyfills\IsExternalInit.cs" />
     <Compile Include="..\Polyfills\RequiredMemberAttribute.cs" Link="Polyfills\RequiredMemberAttribute.cs" />
     <Compile Include="..\Polyfills\CompilerFeatureRequiredAttribute.cs" Link="Polyfills\CompilerFeatureRequiredAttribute.cs" />
-    <Compile Include="..\Polyfills\TaskCompletionSource.cs" Link="Polyfills\TaskCompletionSource.cs" />
     <Compile Include="..\Polyfills\SetsRequiredMembersAttribute.cs" Link="Polyfills\SetsRequiredMembersAttribute.cs" />
     <Compile Include="..\Polyfills\CancellationTokenSourcePolyfillExtensions.cs" Link="Polyfills\CancellationTokenSourcePolyfillExtensions.cs" />
     <Compile Include="..\Polyfills\CancellationTokenPolyfillExtensions.cs" Link="Polyfills\CancellationTokenPolyfillExtensions.cs" />
@@ -31,30 +34,20 @@
     <Using Include="System.ArgumentOutOfRangeException" Alias="ArgumentOutOfRangeExceptionHelper" />
   </ItemGroup>
 
-	<ItemGroup>
-		<InternalsVisibleTo Include="Punchclock.Tests" />
-		<InternalsVisibleTo Include="Punchclock.Benchmarks" />
-	</ItemGroup>
-
-	<ItemGroup>
-    <PackageReference Include="ReactiveUI.Primitives" ExcludeAssets="analyzers" />
-	</ItemGroup>
-
   <ItemGroup>
-    <Using Include="ReactiveUI.Primitives"/>
-    <Using Include="ReactiveUI.Primitives.Concurrency" />
-    <Using Include="ReactiveUI.Primitives.Core" />
-    <Using Include="ReactiveUI.Primitives.Signals" />
-    <Using Include="ReactiveUI.Primitives.RxVoid" Alias="Unit" />
-    <Using Include="ReactiveUI.Primitives.Concurrency.ISequencer" Alias="IScheduler" />
-    <Using Include="ReactiveUI.Primitives.Concurrency.Sequencer" Alias="Scheduler" />
-    <Using Include="ReactiveUI.Primitives.Disposables.Scope" Alias="Disposable" />
+    <Compile Include="..\Punchclock\**\*.cs" Exclude="..\Punchclock\bin\**;..\Punchclock\obj\**" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 
-	<Target Name="RemoveReactiveUIPrimitivesBridgeAnalyzers" BeforeTargets="CoreCompile">
-		<ItemGroup>
-			<Analyzer Remove="@(Analyzer)" Condition="'%(Filename)' == 'ReactiveUI.Primitives.R3Bridge.Generator'" />
-		</ItemGroup>
-	</Target>
+  <ItemGroup>
+    <PackageReference Include="ReactiveUI.Primitives.Reactive" PrivateAssets="analyzers" />
+    <Using Include="System.Reactive.Unit" Alias="Unit" />
+    <Using Include="System.Reactive.Concurrency.IScheduler" Alias="IScheduler" />
+    <Using Include="System.Reactive.Concurrency.Scheduler" Alias="Scheduler" />
+    <Using Include="ReactiveUI.Primitives.Reactive" />
+    <Using Include="ReactiveUI.Primitives.Reactive.Concurrency" />
+    <Using Include="ReactiveUI.Primitives.Core" />
+    <Using Include="ReactiveUI.Primitives.Reactive.Signals" />
+    <Using Include="System.Reactive.Disposables" />
+  </ItemGroup>
 
 </Project>

--- a/src/Punchclock.Tests/KeyedOperationTests.cs
+++ b/src/Punchclock.Tests/KeyedOperationTests.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI.Primitives.Signals;
-using RxVoid = ReactiveUI.Primitives.RxVoid;
+using Unit = ReactiveUI.Primitives.RxVoid;
 
 namespace Punchclock.Tests;
 
@@ -128,7 +128,7 @@ public class KeyedOperationTests
             var op = CreateOperation(priority: 1, key: "test");
             op.CancelledEarly = true;
 
-            var results = new List<RxVoid>();
+            var results = new List<Unit>();
             op.EvaluateFunc().Subscribe(results.Add);
 
             await Assert.That(results).IsEmpty();
@@ -152,7 +152,7 @@ public class KeyedOperationTests
                     return Signal.Emit(42);
                 });
 
-            var results = new List<RxVoid>();
+            var results = new List<Unit>();
             op.EvaluateFunc().Subscribe(results.Add);
 
             await Assert.That(executed).IsTrue();
@@ -166,7 +166,7 @@ public class KeyedOperationTests
     {
         using (Assert.Multiple())
         {
-            var cancelSubject = new Signal<RxVoid>();
+            var cancelSubject = new Signal<Unit>();
             var completed = false;
             var op = CreateOperation(
                 priority: 1,
@@ -176,7 +176,7 @@ public class KeyedOperationTests
 
             op.EvaluateFunc().Subscribe(_ => { }, () => completed = true);
 
-            cancelSubject.OnNext(RxVoid.Default);
+            cancelSubject.OnNext(Unit.Default);
             cancelSubject.OnCompleted();
 
             // TakeUntil completes synchronously when cancel signal completes
@@ -239,7 +239,7 @@ public class KeyedOperationTests
             Func = null, // Null func - should hit line 190
         };
 
-        var results = new List<RxVoid>();
+        var results = new List<Unit>();
         op.EvaluateFunc().Subscribe(results.Add);
 
         await Assert.That(results).IsEmpty();
@@ -261,7 +261,7 @@ public class KeyedOperationTests
         bool useRandom = false,
         int randomOrder = 0,
         Func<IObservable<int>>? func = null,
-        IObservable<RxVoid>? cancelSignal = null) => new()
+        IObservable<Unit>? cancelSignal = null) => new()
         {
             Priority = priority,
             Key = key,

--- a/src/Punchclock.Tests/OperationQueueExtensionsTests.cs
+++ b/src/Punchclock.Tests/OperationQueueExtensionsTests.cs
@@ -6,7 +6,6 @@ using System.Diagnostics.CodeAnalysis;
 using ReactiveUI.Primitives;
 using ReactiveUI.Primitives.Concurrency;
 using ReactiveUI.Primitives.Signals;
-using RxVoid = ReactiveUI.Primitives.RxVoid;
 
 namespace Punchclock.Tests;
 

--- a/src/Punchclock.slnx
+++ b/src/Punchclock.slnx
@@ -18,6 +18,7 @@
     <File Path="testconfig.json" />
   </Folder>
   <Project Path="Punchclock.Benchmarks/Punchclock.Benchmarks.csproj" />
+  <Project Path="Punchclock.Reactive/Punchclock.Reactive.csproj" Id="00cbf112-2779-45e6-93d5-1e5a9051c365" />
   <Project Path="Punchclock.Tests/Punchclock.Tests.csproj" />
   <Project Path="Punchclock/Punchclock.csproj" />
 </Solution>

--- a/src/Punchclock/KeyedOperation.cs
+++ b/src/Punchclock/KeyedOperation.cs
@@ -1,10 +1,13 @@
 // Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
+#if REACTIVE_SHIM
 
-using ReactiveUI.Primitives;
+namespace Punchclock.Reactive;
+#else
 
 namespace Punchclock;
+#endif
 
 /// <summary>
 /// Base class for operations that can be enqueued in an <see cref="OperationQueue"/>.
@@ -43,7 +46,7 @@ internal abstract class KeyedOperation : IComparable<KeyedOperation>
     /// <value>
     /// An observable that emits when cancellation is requested, or null if no cancellation signal is provided.
     /// </value>
-    public IObservable<RxVoid>? CancelSignal { get; init; }
+    public IObservable<Unit>? CancelSignal { get; init; }
 
     /// <summary>
     /// Gets a value indicating whether this operation uses the default (non-keyed) key.
@@ -73,8 +76,8 @@ internal abstract class KeyedOperation : IComparable<KeyedOperation>
     public IDisposable? CancelSubscription { get; set; }
 
     /// <summary>Evaluates the operation function and returns an observable stream.</summary>
-    /// <returns>An observable of <see cref="RxVoid"/> that completes when the operation finishes.</returns>
-    public abstract IObservable<RxVoid> EvaluateFunc();
+    /// <returns>An observable of <see cref="Unit"/> that completes when the operation finishes.</returns>
+    public abstract IObservable<Unit> EvaluateFunc();
 
     /// <summary>
     /// Compares this operation to another for priority-based scheduling.

--- a/src/Punchclock/KeyedOperation{T}.cs
+++ b/src/Punchclock/KeyedOperation{T}.cs
@@ -1,11 +1,13 @@
 // Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
+#if REACTIVE_SHIM
 
-using ReactiveUI.Primitives;
-using ReactiveUI.Primitives.Signals;
+namespace Punchclock.Reactive;
+#else
 
 namespace Punchclock;
+#endif
 
 /// <summary>Typed operation that can be enqueued in an <see cref="OperationQueue"/>. Wraps a user-provided function that returns an observable of <typeparamref name="T"/>.</summary>
 /// <typeparam name="T">The type of value produced by this operation.</typeparam>
@@ -31,25 +33,25 @@ internal sealed class KeyedOperation<T> : KeyedOperation
     /// Respects early cancellation and the cancellation signal.
     /// </summary>
     /// <returns>
-    /// An observable of <see cref="RxVoid"/> that completes when the operation finishes.
+    /// An observable of <see cref="Unit"/> that completes when the operation finishes.
     /// Returns an empty observable if the function is null or the operation was cancelled early.
     /// </returns>
-    public override IObservable<RxVoid> EvaluateFunc()
+    public override IObservable<Unit> EvaluateFunc()
     {
         if (Func is null)
         {
-            return Signal.None<RxVoid>();
+            return Signal.None<Unit>();
         }
 
         if (CancelledEarly)
         {
-            return Signal.None<RxVoid>();
+            return Signal.None<Unit>();
         }
 
-        var signal = CancelSignal ?? Signal.None<RxVoid>();
+        var signal = CancelSignal ?? Signal.None<Unit>();
         var ret = Func().TakeUntil(signal).Multicast(Result);
         ret.Connect();
 
-        return ret.Map(_ => RxVoid.Default);
+        return ret.Map(_ => Unit.Default);
     }
 }

--- a/src/Punchclock/OperationQueue.cs
+++ b/src/Punchclock/OperationQueue.cs
@@ -4,12 +4,14 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using ReactiveUI.Primitives;
-using ReactiveUI.Primitives.Concurrency;
-using ReactiveUI.Primitives.Core;
-using ReactiveUI.Primitives.Signals;
+
+#if REACTIVE_SHIM
+
+namespace Punchclock.Reactive;
+#else
 
 namespace Punchclock;
+#endif
 
 /// <summary>
 /// <para>
@@ -54,7 +56,7 @@ public class OperationQueue : IDisposable
     private readonly HashSet<string> _activeKeys = [];
 
     /// <summary>Sequencer used to start scheduled operations.</summary>
-    private readonly ISequencer _sequencer;
+    private readonly IScheduler _sequencer;
 
     /// <summary>Whether to randomize execution order among equal-priority items across different keys.</summary>
     private readonly bool _randomizeEqualPriority;
@@ -75,7 +77,7 @@ public class OperationQueue : IDisposable
     private bool _isDisposed;
 
     /// <summary>Observable that signals when shutdown is complete. Null until <see cref="ShutdownQueue"/> is called.</summary>
-    private ReplaySignal<RxVoid>? _shutdownObs;
+    private ReplaySignal<Unit>? _shutdownObs;
 
     /// <summary>Tracks whether shutdown has already been signalled.</summary>
     private bool _shutdownCompleted;
@@ -96,7 +98,7 @@ public class OperationQueue : IDisposable
     /// <summary>Initializes a new instance of the <see cref="OperationQueue"/> class with a scheduler.</summary>
     /// <param name="maximumConcurrent">The maximum number of concurrent operations. Must be positive.</param>
     /// <param name="scheduler">Sequencer for controlling execution timing. Useful for testing.</param>
-    public OperationQueue(int maximumConcurrent, ISequencer scheduler)
+    public OperationQueue(int maximumConcurrent, IScheduler scheduler)
         : this(maximumConcurrent, randomizeEqualPriority: false, seed: null, scheduler: scheduler)
     {
     }
@@ -115,12 +117,12 @@ public class OperationQueue : IDisposable
     /// <param name="randomizeEqualPriority">If true, randomizes execution order among equal-priority items across different keys.</param>
     /// <param name="seed">Optional seed to make randomization deterministic for tests.</param>
     /// <param name="scheduler">Sequencer for controlling execution timing. Useful for testing.</param>
-    public OperationQueue(int maximumConcurrent, bool randomizeEqualPriority, int? seed, ISequencer? scheduler)
+    public OperationQueue(int maximumConcurrent, bool randomizeEqualPriority, int? seed, IScheduler? scheduler)
     {
         ArgumentOutOfRangeExceptionHelper.ThrowIfNegativeOrZero(maximumConcurrent);
 
         _maximumConcurrent = maximumConcurrent;
-        _sequencer = scheduler ?? Sequencer.Immediate;
+        _sequencer = scheduler ?? Scheduler.Immediate;
         _randomizeEqualPriority = randomizeEqualPriority;
         if (randomizeEqualPriority)
         {
@@ -159,7 +161,7 @@ public class OperationQueue : IDisposable
             Key = string.IsNullOrEmpty(key) ? DefaultKey : key,
             Id = id,
             Priority = priority,
-            CancelSignal = cancelReplay.Map(_ => RxVoid.Default),
+            CancelSignal = cancelReplay.Map(_ => Unit.Default),
             Func = asyncCalculationFunc,
             UseRandomTiebreak = _randomizeEqualPriority,
             RandomOrder = _randomizeEqualPriority ? _random!.Next() : 0,
@@ -202,7 +204,7 @@ public class OperationQueue : IDisposable
     /// <param name="asyncCalculationFunc">The async method to execute when scheduled.</param>
     /// <returns>An observable that produces the result of the async calculation.</returns>
     public IObservable<T> EnqueueObservableOperation<T>(int priority, string key, Func<IObservable<T>> asyncCalculationFunc) =>
-        EnqueueObservableOperation(priority, key, Signal.Silent<RxVoid>(), asyncCalculationFunc);
+        EnqueueObservableOperation(priority, key, Signal.Silent<Unit>(), asyncCalculationFunc);
 
     /// <summary>This method enqueues an action to be run at a later time, according to the scheduling policies (i.e. via priority).</summary>
     /// <typeparam name="T">The type of item for the observable.</typeparam>
@@ -210,7 +212,7 @@ public class OperationQueue : IDisposable
     /// <param name="asyncCalculationFunc">The async method to execute when scheduled.</param>
     /// <returns>An observable that produces the result of the async calculation.</returns>
     public IObservable<T> EnqueueObservableOperation<T>(int priority, Func<IObservable<T>> asyncCalculationFunc) =>
-        EnqueueObservableOperation(priority, DefaultKey, Signal.Silent<RxVoid>(), asyncCalculationFunc);
+        EnqueueObservableOperation(priority, DefaultKey, Signal.Silent<Unit>(), asyncCalculationFunc);
 
     /// <summary>
     /// This method pauses the dispatch queue. Inflight operations will not
@@ -225,7 +227,7 @@ public class OperationQueue : IDisposable
             ScheduleOperations();
         }
 
-        return ReactiveUI.Primitives.Disposables.Scope.Create(() =>
+        return Disposable.Create(() =>
         {
             if (Interlocked.Decrement(ref _pauseRefCount) > 0)
             {
@@ -268,9 +270,9 @@ public class OperationQueue : IDisposable
     /// </summary>
     /// <returns>An Observable that will signal when all items are complete,
     /// or an error if any operations failed during shutdown.</returns>
-    public IObservable<RxVoid> ShutdownQueue()
+    public IObservable<Unit> ShutdownQueue()
     {
-        ReplaySignal<RxVoid> shutdown;
+        ReplaySignal<Unit> shutdown;
         lock (_gate)
         {
             if (_shutdownObs is not null)
@@ -278,7 +280,7 @@ public class OperationQueue : IDisposable
                 return _shutdownObs;
             }
 
-            shutdown = new ReplaySignal<RxVoid>();
+            shutdown = new ReplaySignal<Unit>();
             _shutdownObs = shutdown;
         }
 
@@ -335,7 +337,7 @@ public class OperationQueue : IDisposable
         for (var i = 0; i < operationsToStart.Count; i++)
         {
             var operation = operationsToStart[i];
-            _sequencer.Schedule((Queue: this, Operation: operation), static state => state.Queue.StartOperation(state.Operation));
+            ScheduleStart(operation);
         }
     }
 
@@ -461,7 +463,7 @@ public class OperationQueue : IDisposable
         for (var i = 0; i < operationsToStart.Count; i++)
         {
             var next = operationsToStart[i];
-            _sequencer.Schedule((Queue: this, Operation: next), static state => state.Queue.StartOperation(state.Operation));
+            ScheduleStart(next);
         }
 
         if (!completeShutdown)
@@ -489,6 +491,25 @@ public class OperationQueue : IDisposable
         CompleteShutdown();
     }
 
+    /// <summary>Schedules an operation start using the active scheduler shape for the current package variant.</summary>
+    /// <param name="operation">The operation to start.</param>
+    private void ScheduleStart(KeyedOperation operation)
+    {
+#if REACTIVE_SHIM
+        _sequencer.Schedule(
+            (Queue: this, Operation: operation),
+            static (_, state) =>
+            {
+                state.Queue.StartOperation(state.Operation);
+                return Disposable.Empty;
+            });
+#else
+        _sequencer.Schedule(
+            (Queue: this, Operation: operation),
+            static state => state.Queue.StartOperation(state.Operation));
+#endif
+    }
+
     /// <summary>Determines whether shutdown can be signalled.</summary>
     /// <returns><see langword="true"/> if shutdown is ready; otherwise, <see langword="false"/>.</returns>
     private bool IsShutdownReady()
@@ -506,7 +527,7 @@ public class OperationQueue : IDisposable
     private void CompleteShutdown()
     {
         var shutdown = Volatile.Read(ref _shutdownObs)!;
-        shutdown.OnNext(RxVoid.Default);
+        shutdown.OnNext(Unit.Default);
         shutdown.OnCompleted();
     }
 }

--- a/src/Punchclock/OperationQueueExtensions.cs
+++ b/src/Punchclock/OperationQueueExtensions.cs
@@ -2,12 +2,13 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using ReactiveUI.Primitives;
-using ReactiveUI.Primitives.Concurrency;
-using ReactiveUI.Primitives.Disposables;
-using ReactiveUI.Primitives.Signals;
+#if REACTIVE_SHIM
+
+namespace Punchclock.Reactive;
+#else
 
 namespace Punchclock;
+#endif
 
 /// <summary>Extension methods associated with the <see cref="OperationQueue"/>. Provides convenient Task-based overloads for enqueueing operations.</summary>
 public static class OperationQueueExtensions
@@ -23,7 +24,7 @@ public static class OperationQueueExtensions
         /// <param name="asyncOperation">The async method to execute when scheduled.</param>
         /// <param name="token">A cancellation token which if signalled, will cancel the operation.</param>
         /// <returns>A task that completes when the operation completes, containing the result.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="operationQueue"/> or <paramref name="asyncOperation"/> is null.</exception>
+        /// <exception cref="ArgumentExceptionHelper">Thrown when <paramref name="operationQueue"/> or <paramref name="asyncOperation"/> is null.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled via <paramref name="token"/>.</exception>
         public Task<T> Enqueue<T>(int priority, string key, Func<Task<T>> asyncOperation, CancellationToken token)
         {
@@ -33,7 +34,7 @@ public static class OperationQueueExtensions
             // Fast path: if token can't be cancelled, avoid registration overhead.
             if (!token.CanBeCanceled)
             {
-                return operationQueue.EnqueueObservableOperation(priority, key, Signal.Silent<RxVoid>(), () => Signal.FromTask(asyncOperation()))
+                return operationQueue.EnqueueObservableOperation(priority, key, Signal.Silent<Unit>(), () => Signal.FromTask(asyncOperation()))
                     .ToTask(CancellationToken.None);
             }
 
@@ -53,7 +54,7 @@ public static class OperationQueueExtensions
         /// <param name="asyncOperation">The async method to execute when scheduled.</param>
         /// <param name="token">A cancellation token which if signalled, will cancel the operation.</param>
         /// <returns>A task that completes when the operation completes.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="operationQueue"/> or <paramref name="asyncOperation"/> is null.</exception>
+        /// <exception cref="ArgumentExceptionHelper">Thrown when <paramref name="operationQueue"/> or <paramref name="asyncOperation"/> is null.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled via <paramref name="token"/>.</exception>
         public Task Enqueue(int priority, string key, Func<Task> asyncOperation, CancellationToken token)
         {
@@ -63,7 +64,7 @@ public static class OperationQueueExtensions
             // Fast path: if token can't be cancelled, avoid registration overhead.
             if (!token.CanBeCanceled)
             {
-                return operationQueue.EnqueueObservableOperation(priority, key, Signal.Silent<RxVoid>(), () => Signal.FromTask(ToRxVoidTask(asyncOperation)))
+                return operationQueue.EnqueueObservableOperation(priority, key, Signal.Silent<Unit>(), () => Signal.FromTask(ToRxVoidTask(asyncOperation)))
                     .ToTask(CancellationToken.None);
             }
 
@@ -83,13 +84,13 @@ public static class OperationQueueExtensions
         /// <param name="key">A key to apply to the operation. Items with the same key will be run in order. Pass null for non-keyed operations.</param>
         /// <param name="asyncOperation">The async method to execute when scheduled.</param>
         /// <returns>A task that completes when the operation completes, containing the result.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="operationQueue"/> or <paramref name="asyncOperation"/> is null.</exception>
+        /// <exception cref="ArgumentExceptionHelper">Thrown when <paramref name="operationQueue"/> or <paramref name="asyncOperation"/> is null.</exception>
         public Task<T> Enqueue<T>(int priority, string key, Func<Task<T>> asyncOperation)
         {
             ArgumentExceptionHelper.ThrowIfNull(operationQueue);
             ArgumentExceptionHelper.ThrowIfNull(asyncOperation);
 
-            return operationQueue.EnqueueObservableOperation(priority, key, Signal.Silent<RxVoid>(), () => Signal.FromTask(asyncOperation()))
+            return operationQueue.EnqueueObservableOperation(priority, key, Signal.Silent<Unit>(), () => Signal.FromTask(asyncOperation()))
                 .ToTask();
         }
 
@@ -98,13 +99,13 @@ public static class OperationQueueExtensions
         /// <param name="key">A key to apply to the operation. Items with the same key will be run in order. Pass null for non-keyed operations.</param>
         /// <param name="asyncOperation">The async method to execute when scheduled.</param>
         /// <returns>A task that completes when the operation completes.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="operationQueue"/> or <paramref name="asyncOperation"/> is null.</exception>
+        /// <exception cref="ArgumentExceptionHelper">Thrown when <paramref name="operationQueue"/> or <paramref name="asyncOperation"/> is null.</exception>
         public Task Enqueue(int priority, string key, Func<Task> asyncOperation)
         {
             ArgumentExceptionHelper.ThrowIfNull(operationQueue);
             ArgumentExceptionHelper.ThrowIfNull(asyncOperation);
 
-            return operationQueue.EnqueueObservableOperation(priority, key, Signal.Silent<RxVoid>(), () => Signal.FromTask(ToRxVoidTask(asyncOperation)))
+            return operationQueue.EnqueueObservableOperation(priority, key, Signal.Silent<Unit>(), () => Signal.FromTask(ToRxVoidTask(asyncOperation)))
                 .ToTask();
         }
 
@@ -116,7 +117,7 @@ public static class OperationQueueExtensions
         /// <param name="priority">The priority of operation. Higher priorities run before lower ones.</param>
         /// <param name="asyncOperation">The async method to execute when scheduled.</param>
         /// <returns>A task that completes when the operation completes, containing the result.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="operationQueue"/> or <paramref name="asyncOperation"/> is null.</exception>
+        /// <exception cref="ArgumentExceptionHelper">Thrown when <paramref name="operationQueue"/> or <paramref name="asyncOperation"/> is null.</exception>
         public Task<T> Enqueue<T>(int priority, Func<Task<T>> asyncOperation)
         {
             ArgumentExceptionHelper.ThrowIfNull(operationQueue);
@@ -133,7 +134,7 @@ public static class OperationQueueExtensions
         /// <param name="priority">The priority of operation. Higher priorities run before lower ones.</param>
         /// <param name="asyncOperation">The async method to execute when scheduled.</param>
         /// <returns>A task that completes when the operation completes.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="operationQueue"/> or <paramref name="asyncOperation"/> is null.</exception>
+        /// <exception cref="ArgumentExceptionHelper">Thrown when <paramref name="operationQueue"/> or <paramref name="asyncOperation"/> is null.</exception>
         public Task Enqueue(int priority, Func<Task> asyncOperation)
         {
             ArgumentExceptionHelper.ThrowIfNull(operationQueue);
@@ -147,14 +148,14 @@ public static class OperationQueueExtensions
     /// <summary>Converts a <see cref="CancellationToken"/> to an observable that signals when cancellation is requested.</summary>
     /// <param name="token">The cancellation token to convert.</param>
     /// <returns>
-    /// An observable that emits <see cref="RxVoid.Default"/> when the token is cancelled.
+    /// An observable that emits <see cref="Unit.Default"/> when the token is cancelled.
     /// For non-cancellable tokens, returns an observable that never completes (fast path).
     /// </returns>
     /// <exception cref="OperationCanceledException">Thrown immediately if the token is already cancelled.</exception>
 #if NET8_0_OR_GREATER
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
 #endif
-    internal static IObservable<RxVoid> ConvertTokenToObservable(CancellationToken token) =>
+    internal static IObservable<Unit> ConvertTokenToObservable(CancellationToken token) =>
         ConvertTokenToObservable(null, token);
 
     /// <summary>
@@ -164,40 +165,40 @@ public static class OperationQueueExtensions
     /// <param name="scheduler">Optional sequencer for subscription. Used for testing temporal behavior.</param>
     /// <param name="token">The cancellation token to convert.</param>
     /// <returns>
-    /// An observable that emits <see cref="RxVoid.Default"/> when the token is cancelled.
+    /// An observable that emits <see cref="Unit.Default"/> when the token is cancelled.
     /// For non-cancellable tokens, returns an observable that never completes (fast path).
     /// </returns>
     /// <exception cref="OperationCanceledException">Thrown immediately if the token is already cancelled.</exception>
 #if NET8_0_OR_GREATER
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
 #endif
-    internal static IObservable<RxVoid> ConvertTokenToObservable(ISequencer? scheduler, CancellationToken token)
+    internal static IObservable<Unit> ConvertTokenToObservable(IScheduler? scheduler, CancellationToken token)
     {
         // Fast path: non-cancellable tokens never cancel, so return never-completing observable
         if (!token.CanBeCanceled)
         {
-            return Signal.Silent<RxVoid>();
+            return Signal.Silent<Unit>();
         }
 
         // Fast path: already cancelled tokens throw immediately
         if (token.IsCancellationRequested)
         {
-            return Signal.Fail<RxVoid>(new OperationCanceledException(token));
+            return Signal.Fail<Unit>(new OperationCanceledException(token));
         }
 
         // Standard path: create observable that signals on cancellation
-        var obs = Signal.Create<RxVoid>(observer =>
+        var obs = Signal.Create<Unit>(observer =>
         {
             // Double-check cancellation after observable creation
             if (token.IsCancellationRequested)
             {
                 observer.OnError(new OperationCanceledException(token));
-                return Scope.Empty;
+                return Disposable.Empty;
             }
 
             return token.Register(() =>
             {
-                observer.OnNext(RxVoid.Default);
+                observer.OnNext(Unit.Default);
                 observer.OnCompleted();
             });
         });
@@ -205,12 +206,12 @@ public static class OperationQueueExtensions
         return scheduler is not null ? obs.SubscribeOn(scheduler) : obs;
     }
 
-    /// <summary>Converts a non-generic task operation into a task that emits <see cref="RxVoid"/>.</summary>
+    /// <summary>Converts a non-generic task operation into a task that emits <see cref="Unit"/>.</summary>
     /// <param name="asyncOperation">The async operation to execute.</param>
-    /// <returns>A task that produces <see cref="RxVoid.Default"/> after completion.</returns>
-    private static async Task<RxVoid> ToRxVoidTask(Func<Task> asyncOperation)
+    /// <returns>A task that produces <see cref="Unit.Default"/> after completion.</returns>
+    private static async Task<Unit> ToRxVoidTask(Func<Task> asyncOperation)
     {
         await asyncOperation().ConfigureAwait(false);
-        return RxVoid.Default;
+        return Unit.Default;
     }
 }

--- a/src/Punchclock/PriorityQueueHelper.cs
+++ b/src/Punchclock/PriorityQueueHelper.cs
@@ -4,7 +4,13 @@
 
 using System.Runtime.CompilerServices;
 
+#if REACTIVE_SHIM
+
+namespace Punchclock.Reactive;
+#else
+
 namespace Punchclock;
+#endif
 
 /// <summary>
 /// Internal helper class providing static heap operations for priority queues.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature and migration support for System.Reactive consumers.

## What is the new behavior?

Adds a `Punchclock.Reactive` project that links the shared Punchclock source with `REACTIVE_SHIM` enabled and references `ReactiveUI.Primitives.Reactive`. The reactive package variant exposes System.Reactive-friendly `Unit` and `IScheduler` shapes while the existing lean `Punchclock` package continues to use ReactiveUI.Primitives `RxVoid` and `ISequencer`.

The shared queue code now has package-variant aliases for scheduler, unit, and disposable types, plus a scheduler helper that handles the System.Reactive `IScheduler` delegate signature. The new project is included in the solution and has PublicAPI baselines for every target framework.

## What is the current behavior?

Punchclock only builds the lean ReactiveUI.Primitives package variant, so System.Reactive-first consumers do not have a dedicated package surface compiled against System.Reactive scheduler and unit conventions.

## Checklist
- [x] I have read the Contribute guide
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows Conventional Commits

## Additional information

Validation completed locally:

- `dotnet restore .\Punchclock.slnx`
- `dotnet build .\Punchclock.slnx -c Release --no-restore /clp:ErrorsOnly`
- `dotnet test --project .\Punchclock.Tests\Punchclock.Tests.csproj -c Release --framework net8.0 --coverage --coverage-output-format cobertura --results-directory .\TestResults\net8.0 -- --disable-logo --report-trx --maximum-parallel-tests 1`
- Repeated the same MTP/TUnit coverage run for `net9.0`, `net10.0`, and `net11.0`
- `mtpunittestmcp` solution coverage reported 100% line coverage and no missed coverage

No local Contribute/CONTRIBUTING guide file was present in this checkout.